### PR TITLE
feat: support commands from command mode to insert mode

### DIFF
--- a/src/utils/ui/mode/mode.rs
+++ b/src/utils/ui/mode/mode.rs
@@ -213,8 +213,43 @@ impl KeyEventCallback for Command {
                 return Ok(WarpUiCallBackType::ChangMode(ModeType::LastLine));
             }
 
-            b"i" | b"I" => {
-                // 切换Insert模式
+            b"i" => {
+                // 切换Insert模式，从光标前开始插入字符
+                return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
+            }
+
+            b"I" => {
+                // 切换Insert模式，从行首开始插入字符
+                ui.cursor.move_to_previous_line(0)?;
+                return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
+            }
+
+            b"a" => {
+                // 切换Insert模式，在光标后开始输入文本
+                ui.cursor.move_right(1)?;
+                return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
+            }
+
+            b"A" => {
+                // 切换Insert模式，在行尾开始输入文本
+                let linesize = ui.buffer.get_linesize(ui.cursor.y());
+                ui.cursor.move_to_columu(linesize - 1)?;
+                return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
+            }
+
+            b"o" => {
+                // 切换Insert模式，在当前行的下方插入一个新行开始输入文本
+                let linesize = ui.buffer.get_linesize(ui.cursor.y());
+                ui.cursor.move_to_columu(linesize - 1)?;
+                ui.buffer.input_enter(ui.cursor.x(), ui.cursor.y());
+                ui.cursor.move_to_nextline(1)?;
+                return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
+            }
+
+            b"O" => {
+                // 切换Insert模式，在当前行的上方插入一个新行开始输入文本
+                ui.cursor.move_to_previous_line(0)?;
+                ui.buffer.input_enter(ui.cursor.x(), ui.cursor.y());
                 return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
             }
 
@@ -260,11 +295,6 @@ impl KeyEventCallback for Command {
             b"w" | b"W" => {
                 // 跳转到下一个flag行
                 self.jump_to_next_flag(ui, LineState::FLAGED)?;
-                return Ok(WarpUiCallBackType::None);
-            }
-
-            b"a" | b"A" => {
-                self.jump_to_previous_flag(ui, LineState::LOCKED)?;
                 return Ok(WarpUiCallBackType::None);
             }
 

--- a/src/utils/ui/mode/mode.rs
+++ b/src/utils/ui/mode/mode.rs
@@ -220,7 +220,7 @@ impl KeyEventCallback for Command {
 
             b"I" => {
                 // 切换Insert模式，从行首开始插入字符
-                ui.cursor.move_to_previous_line(0)?;
+                ui.cursor.move_to_columu(0)?;
                 return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
             }
 
@@ -248,7 +248,7 @@ impl KeyEventCallback for Command {
 
             b"O" => {
                 // 切换Insert模式，在当前行的上方插入一个新行开始输入文本
-                ui.cursor.move_to_previous_line(0)?;
+                ui.cursor.move_to_columu(0)?;
                 ui.buffer.input_enter(ui.cursor.x(), ui.cursor.y());
                 return Ok(WarpUiCallBackType::ChangMode(ModeType::Insert));
             }


### PR DESCRIPTION
实现从command模式到insert模式的按键，与vim相同
i：从光标前开始插入字符
I：从行首开始插入字符
a：从光标后开始插入字符
A：从行尾开始插入字符
o：在当前行之下另起一行，开始插入字符
O：在当前行之上另起一行，开始插入字符

原i|I进入插入模式被修改。
原a|A跳转到下一个锁定行被修改，需要商量另一个按键来使用