### PR TITLE
 fix(render): 修正渲染缓冲区中多字节字符处理逻辑

### DIFF
--- a/held_core/src/interface/app.rs
+++ b/held_core/src/interface/app.rs
@@ -1,4 +1,4 @@
-use super::{get_application, APPLICATION};
+use super::get_application;
 
 pub trait App {
     fn exit(&mut self);

--- a/held_core/src/view/render/mod.rs
+++ b/held_core/src/view/render/mod.rs
@@ -1,5 +1,3 @@
-use std::str::Chars;
-
 use cell::Cell;
 
 use crate::utils::{position::Position, rectangle::Rectangle};

--- a/src/application/handler/app.rs
+++ b/src/application/handler/app.rs
@@ -1,4 +1,3 @@
-use crate::application::mode::command::CommandData;
 use crate::application::mode::{ModeData, ModeKey};
 use crate::application::Application;
 use crate::errors::*;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -12,7 +12,7 @@ use mode::{
 use smallvec::SmallVec;
 use state::ApplicationStateData;
 
-use std::{cell::RefCell, collections::HashMap, mem, rc::Rc, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, mem, rc::Rc};
 
 use crate::{
     modules::perferences::{Perferences, PerferencesManager},

--- a/src/application/mode/command.rs
+++ b/src/application/mode/command.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, process::CommandArgs};
-
 use held_core::{
     utils::position::Position,
     view::{colors::Colors, style::CharStyle},

--- a/src/modules/perferences/yaml.rs
+++ b/src/modules/perferences/yaml.rs
@@ -1,13 +1,5 @@
-use std::path::PathBuf;
-
-use super::{
-    Perferences, APP_INFO, LINE_WRAPPING_KEY, SOFT_TAB_KEY, TAB_WIDTH_KEY, THEME_KET, THEME_PATH,
-};
-use crate::{
-    errors::*,
-    modules::perferences::{LANGUAGE_KEY, LANGUAGE_SYNTAX_KEY, SYNTAX_PATH},
-};
-use app_dirs2::{app_dir, AppDataType};
+use super::{Perferences, LINE_WRAPPING_KEY, SOFT_TAB_KEY, TAB_WIDTH_KEY, THEME_KET};
+use crate::modules::perferences::{LANGUAGE_KEY, LANGUAGE_SYNTAX_KEY};
 use yaml_rust::Yaml;
 
 pub struct YamlPerferences {

--- a/src/view/presenter.rs
+++ b/src/view/presenter.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cell::RefCell, fmt::Debug, rc::Rc};
+use std::{borrow::Cow, fmt::Debug};
 
 use super::{
     colors::map::ColorMap,

--- a/src/view/render/render_buffer.rs
+++ b/src/view/render/render_buffer.rs
@@ -59,11 +59,12 @@ impl CachedRenderBuffer {
 
             if !equal {
                 let mut cache_cell = CachedCell::default();
-                let content_len = cell_content.len();
+                let grapheme_count = cell.content.graphemes(true).count().max(1);
                 cache_cell.colors = cell.colors;
                 cache_cell.style = cell.style;
                 cache_cell.content = cell_content;
-                for i in (index + 1)..(index + content_len) {
+                let end_index = (index + grapheme_count).min(self.cells.len());
+                for i in (index + 1)..end_index {
                     self.cells[i] = None
                 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -190,7 +190,6 @@ impl Workspace {
             .or_else(|| Some(self.syntax_set.find_syntax_plain_text()))
             .cloned();
 
-        drop(buffer);
         self.get_buffer_mut(id)
             .ok_or(ErrorKind::EmptyWorkspace)?
             .syntax_definition = definition;


### PR DESCRIPTION
commit a16d7dda2fe719a9272f3a6fe79c3b9d1aaa66df 
Author: longjin <longjin@DragonOS.org>
Date:   Thu Jun 12 01:23:34 2025 +0800

    refactor: 清理未使用的导入语句
    
    移除多个文件中未使用的导入语句，优化代码结构。
    
    Signed-off-by: longjin <longjin@DragonOS.org>

commit 5adb70542c3418a2a97e94f54ae4fe8c2ff33dab
Author: longjin <longjin@DragonOS.org>
Date:   Wed Jun 11 23:54:19 2025 +0800

    fix(render): 修正渲染缓冲区中多字节字符处理逻辑
    
    将字符长度计算方式改为基于grapheme clusters，并添加边界检查防止越界。
    
    Signed-off-by: longjin <longjin@DragonOS.org>